### PR TITLE
POD: remove obsolete statement in AUTHOR section

### DIFF
--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -297,8 +297,6 @@ L<Test::MockObject> -- use this if you need to alter an entire class
 
 Curtis "Ovid" Poe, C<< <ovid [at] cpan [dot] org> >>
 
-Reverse the name to email me.
-
 =head1 COPYRIGHT AND LICENSE
 
 Copyright (C) 2004-2005 by Curtis "Ovid" Poe


### PR DESCRIPTION
Since 0.07 the e-mail address of the author is not reversed, so the statement that tells to reverse it is obsolete.