### PR TITLE
Add a wrap feature similar to moose's 'around'.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
-Revision history for Perl extension Sub::Override.
+0.10  Wed Nov 22 2023
+      Add a 'wrap' routine that allows you to call the original sub.
 
 0.09  Wed Jan 16 2013
       Switch from Test::Exception to Test::Fatal.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sub::Override - Perl extension for easily overriding subroutines
 
 # VERSION
 
-0.09
+0.10
 
 # SYNOPSIS
 
@@ -23,7 +23,7 @@ Sub::Override - Perl extension for easily overriding subroutines
 ## The Problem
 
 Sometimes subroutines need to be overridden.  In fact, your author does this
-constantly for tests.  Particularly when testing, using a Mock Object can be
+frequently for tests.  Particularly when testing, using a Mock Object can be
 overkill when all you want to do is override one tiny, little function.
 
 Overriding a subroutine is often done with syntax similar to the following.
@@ -89,10 +89,26 @@ when testing how code behaves with multiple conditions.
     $override->replace('Some::thing', sub { 1 });
     is($object->foo, 'puppies', 'puppies are returned if Some::thing is true');
 
+## Wrapping a subroutine
+
+There may be times when you want to 'conditionally' replace a subroutine - for
+example, to override the original subroutine only if certain args are passed.
+For this you can specify 'wrap' instead of 'replace'. Wrap is identical to
+replace, except the original subroutine is passed as the first arg to your
+new subroutine. You can call the original sub via 'shift->(@\_)':
+
+    $override->wrap('Some::sub',
+      sub {
+        my ($old_sub, @args) = @_;
+        return 1 if $args[0];
+        return $old_sub->(@args);
+      }
+    );
+
 ## Restoring subroutines
 
 If the object falls out of scope, the original subs are restored.  However, if
-you need to restore a subroutine early, just use the restore method:
+you need to restore a subroutine early, just use the `restore()` method:
 
     my $override = Sub::Override->new('Some::sub', sub {'new data'});
     # do stuff
@@ -105,7 +121,7 @@ Which is somewhat equivalent to:
       # do stuff
     }
 
-If you have override more than one subroutine with an override object, you
+If you have overridden more than one subroutine with an override object, you
 will have to explicitly name the subroutine you wish to restore:
 
     $override->restore('This::sub');
@@ -134,7 +150,7 @@ current package.
     my $sub = Sub::Override->new;
     my $sub = Sub::Override->new($sub_name, $sub_ref);
 
-Creates a new `Sub::Override` instance.  Optionally, you may override a 
+Creates a new `Sub::Override` instance.  Optionally, you may override a
 subroutine while creating a new object.
 
 ## replace
@@ -147,7 +163,7 @@ instance, so chaining the method is allowed:
     $sub->replace($sub_name, $sub_body)
         ->replace($another_sub, $another_body);
 
-This method will `croak` is the subroutine to be replaced does not exist.
+This method will `croak` if the subroutine to be replaced does not exist.
 
 ## override
 
@@ -167,26 +183,47 @@ automatically if the `Sub::Override` object falls out of scope.
 
 None by default.
 
+# CAVEATS
+
+If you need to override the same sub several times do not create a new
+`Sub::Override` object, but instead always reuse the existing one and call 
+`replace` on it. Creating a new object to override the same sub will result
+in weird behavior.
+
+    # Do not do this!
+    my $sub_first = Sub::Override->new( 'Foo:bar' => sub { 'first' } );
+    my $sub_second = Sub::Override->new( 'Foo::bar' => sub { 'second' } );
+
+    # Do not do this either!
+    my $sub = Sub::Override->new( 'Foo::bar' => sub { 'first' } );
+    $sub = Sub::Override->new( 'Foo::bar' => sub { 'second' } );
+    
+
+Both of those usages could result in of your subs being lost, depending
+on the order in which you restore them.
+
+Instead, call `replace` on the existing `$sub`.
+
+    my $sub = Sub::Override->new( 'Foo::bar' => sub { 'first' } );
+    $sub->replace( 'Foo::bar' => sub { 'second' } );
+
 # BUGS
 
 Probably.  Tell me about 'em.
 
 # SEE ALSO
 
-- Hook::LexWrap -- can also override subs, but with different capabilities
-- Test::MockObject -- use this if you need to alter an entire class
+- [Hook::LexWrap](https://metacpan.org/pod/Hook%3A%3ALexWrap) -- can also override subs, but with different capabilities
+- [Test::MockObject](https://metacpan.org/pod/Test%3A%3AMockObject) -- use this if you need to alter an entire class
 
 # AUTHOR
 
 Curtis "Ovid" Poe, `<ovid [at] cpan [dot] org>`
 
-Reverse the name to email me.
-
 # COPYRIGHT AND LICENSE
 
-Copyright (C) 2004-2005 by Curtis "Ovid" Poe
+Copyright (C) 2004-2013 by Curtis "Ovid" Poe
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.2 or,
 at your option, any later version of Perl 5 you may have available.
-

--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -3,7 +3,7 @@ package Sub::Override;
 use strict;
 use warnings;
 
-our $VERSION = '0.09';
+our $VERSION = '0.10';
 
 my $_croak = sub {
     local *__ANON__ = '__ANON__croak';
@@ -123,7 +123,7 @@ Sub::Override - Perl extension for easily overriding subroutines
 
 =head1 VERSION
 
-0.09
+0.10
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Adds a simple feature to allow you to call the original subroutine if you conditionally don't want to override it.