### PR TITLE
Auto-detect prototypes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,9 +7,9 @@ WriteMakefile(
     NAME         => 'Sub::Override',
     VERSION_FROM => 'lib/Sub/Override.pm',    # finds $VERSION
     PREREQ_PM    => {
-        'Sub::Util'   => '1.40',
-        'Test::More'  => .47,
-        'Test::Fatal' => '0.010',
+        'Scalar::Util' => '1.11',
+        'Test::More'   => .47,
+        'Test::Fatal'  => '0.010',
     },
     (   $] >= 5.005
         ? ( ABSTRACT_FROM => 'lib/Sub/Override.pm',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,9 +7,9 @@ WriteMakefile(
     NAME         => 'Sub::Override',
     VERSION_FROM => 'lib/Sub/Override.pm',    # finds $VERSION
     PREREQ_PM    => {
-        'Sub::Prototype' => '0.02',
-        'Test::More'     => .47,
-        'Test::Fatal'    => '0.010',
+        'Sub::Util'   => '1.40',
+        'Test::More'  => .47,
+        'Test::Fatal' => '0.010',
     },
     (   $] >= 5.005
         ? ( ABSTRACT_FROM => 'lib/Sub/Override.pm',

--- a/README.md
+++ b/README.md
@@ -75,11 +75,6 @@ programmer to chain the calls, if this style of programming is preferred:
              ->replace('Some::sub2', sub { 'new data2' })
              ->replace('Some::sub3', sub { 'new data3' });
 
-If the subroutine has a prototype, the new subroutine should be declared with
-same prototype as original one:
-
-    $override->replace('Some::sub_with_proto', sub ($$) { ($_[0], $_ [1]) });
-
 A subroutine may be replaced as many times as desired.  This is most useful
 when testing how code behaves with multiple conditions.
 

--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -3,7 +3,7 @@ package Sub::Override;
 use strict;
 use warnings;
 
-use Sub::Prototype qw(set_prototype);
+use Sub::Util qw(set_prototype);
 
 our $VERSION = '0.12';
 
@@ -83,7 +83,7 @@ sub replace {
         no strict 'refs';
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
         my $prototype = prototype($self->{$sub_to_replace});
-        set_prototype($new_sub, $prototype) if defined $prototype;
+        set_prototype($prototype, $new_sub) if defined $prototype;
         no warnings 'redefine';
         *$sub_to_replace = $new_sub;
     }
@@ -112,7 +112,7 @@ sub wrap {
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
         my $code =  sub { unshift @_, $self->{$sub_to_replace}; goto &$new_sub };
         my $prototype = prototype($self->{$sub_to_replace});
-        set_prototype($code, $prototype) if defined $prototype;
+        set_prototype($prototype, $code) if defined $prototype;
         no warnings 'redefine';
         *$sub_to_replace = $code;
     }

--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -3,7 +3,7 @@ package Sub::Override;
 use strict;
 use warnings;
 
-use Sub::Util qw(set_prototype);
+use Scalar::Util qw(set_prototype);
 
 our $VERSION = '0.12';
 
@@ -82,8 +82,7 @@ sub replace {
     {
         no strict 'refs';
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
-        my $prototype = prototype($self->{$sub_to_replace});
-        set_prototype($prototype, $new_sub) if defined $prototype;
+        set_prototype(\&$new_sub, prototype($self->{$sub_to_replace}));
         no warnings 'redefine';
         *$sub_to_replace = $new_sub;
     }
@@ -111,8 +110,7 @@ sub wrap {
         no strict 'refs';
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
         my $code =  sub { unshift @_, $self->{$sub_to_replace}; goto &$new_sub };
-        my $prototype = prototype($self->{$sub_to_replace});
-        set_prototype($prototype, $code) if defined $prototype;
+        set_prototype(\&$code, prototype($self->{$sub_to_replace}));
         no warnings 'redefine';
         *$sub_to_replace = $code;
     }

--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -82,6 +82,8 @@ sub replace {
     {
         no strict 'refs';
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
+        my $prototype = prototype($self->{$sub_to_replace});
+        set_prototype($new_sub, $prototype) if defined $prototype;
         no warnings 'redefine';
         *$sub_to_replace = $new_sub;
     }
@@ -236,11 +238,6 @@ programmer to chain the calls, if this style of programming is preferred:
   $override->replace('Some::sub1', sub { 'new data1' })
            ->replace('Some::sub2', sub { 'new data2' })
            ->replace('Some::sub3', sub { 'new data3' });
-
-If the subroutine has a prototype, the new subroutine should be declared with
-same prototype as original one:
-
-  $override->replace('Some::sub_with_proto', sub ($$) { ($_[0], $_ [1]) });
 
 A subroutine may be replaced as many times as desired.  This is most useful
 when testing how code behaves with multiple conditions.

--- a/t/override.t
+++ b/t/override.t
@@ -124,6 +124,7 @@ is( Foo::bar(), 'original value',
     package TempReplace;
     sub foo {23}
     sub bar {42}
+    sub baz ($$) {$_[0] + $_[1]}
 
     my $override = $CLASS->new( 'foo', sub {42} );
     $override->replace( 'bar', sub {'barbar'} );
@@ -134,6 +135,11 @@ is( Foo::bar(), 'original value',
 
     $override->restore('TempReplace::bar');
     main::is( bar(), 42, '... even if we use a full qualified sub name' );
+
+    $override->replace( 'baz', sub {$_[0] . $_[1]} );
+    main::is( baz(4,2), 42, 'Replace prototyped sub' );
+    $override->restore('baz');
+    main::is( baz(4,2), 6, '... and we should be able to restore said sub' );
 }
 
 can_ok( $override, 'wrap' );


### PR DESCRIPTION
Sorry for being late with this fix of an inconsistency: As of version 0.11 `Sub::Override` uses `Sub::Prototype`, that means an auto-detection of prototypes is now possible. Maybe this could be part of your inject feature implementation.