### PR TITLE
use Scalar::Util::set_prototype rather than Sub::Prototype

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ WriteMakefile(
     NAME         => 'Sub::Override',
     VERSION_FROM => 'lib/Sub/Override.pm',    # finds $VERSION
     PREREQ_PM    => {
-        'Sub::Prototype' => '0.02',
+        'Scalar::Util' => '1.11',
         'Test::More'     => .47,
         'Test::Fatal'    => '0.010',
     },

--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -3,7 +3,7 @@ package Sub::Override;
 use strict;
 use warnings;
 
-use Sub::Prototype qw(set_prototype);
+use Scalar::Util qw(set_prototype);
 
 our $VERSION = '0.11';
 
@@ -87,7 +87,7 @@ sub wrap {
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
         my $code =  sub { unshift @_, $self->{$sub_to_replace}; goto &$new_sub };
         my $prototype = prototype($self->{$sub_to_replace});
-        set_prototype($code, $prototype) if defined $prototype;
+        set_prototype(\&$code, $prototype) if defined $prototype;
         no warnings 'redefine';
         *$sub_to_replace = $code;
     }


### PR DESCRIPTION
Scalar::Util's set_prototype has been available in core since perl 5.8.1.