### PR TITLE
Allow override object to be destroyed on undef when using wrap.

### DIFF
--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -85,9 +85,13 @@ sub wrap {
     {
         no strict 'refs';
         $self->{$sub_to_replace} ||= *$sub_to_replace{CODE};
-        my $code =  sub { unshift @_, $self->{$sub_to_replace}; goto &$new_sub };
+
+        # passing $sub_to_replace directly to arguments prevents early destruction.
+        my $weakened_sub_to_replace = $self->{$sub_to_replace};
+        my $code = sub { unshift(@_, $weakened_sub_to_replace); goto &$new_sub };
         my $prototype = prototype($self->{$sub_to_replace});
         set_prototype(\&$code, $prototype) if defined $prototype;
+
         no warnings 'redefine';
         *$sub_to_replace = $code;
     }

--- a/t/override.t
+++ b/t/override.t
@@ -167,6 +167,7 @@ can_ok( $override, 'wrap' );
     main::is( bar(5,2),  7,  '... and wrapped prototyped sub bar conditionally returns original value' );
     main::is( bar(4,2),  42, '... and wrapped prototyped sub bar conditionally returns override value' );
 
-    $override->restore('bar');
+    # make sure there are no left-over references preventing destroy from running.
+    undef $override;
     main::is( bar(4,2), 6, '... and we can restore a wrapped subroutine' );
 }


### PR DESCRIPTION
When using wrap, the first arg to the wrap routine  held the parent object reference which prevented object destruction when it went out of scope.