### PR TITLE
Allow hashes to be passed to the override routines.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+0.13  Wed Jun 19 2024
+    - Allow a hash of sub/codref for each override routine rather than one at a time.
+
 0.12  Mon Jun 17 2024
     - Add 'inject' method which can inject a new subroutine into a namespace.
     - Add 'inherit' method which can inherit a subroutine from a parent object.

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Sub-Override version 0.12
+Sub-Override version 0.13
 =========================
 
 INSTALLATION

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sub::Override - Perl extension for easily overriding subroutines
 
 # VERSION
 
-0.12
+0.13
 
 # SYNOPSIS
 
@@ -56,46 +56,41 @@ the exact syntax.
 Instead, `Sub::Override` allows the programmer to simply name the sub to
 replace and to supply a sub to replace it with.
 
-    my $override = Sub::Override->new('Some::sub', sub {'new data'});
+    my $override = Sub::Override->new('Some::sub => sub {'new data'});
 
     # which is equivalent to:
     my $override = Sub::Override->new;
-    $override->replace('Some::sub', sub { 'new data' });
+    $override->replace('Some::sub' => sub { 'new data' });
 
 You can replace multiple subroutines, if needed:
 
-    $override->replace('Some::sub1', sub { 'new data1' });
-    $override->replace('Some::sub2', sub { 'new data2' });
-    $override->replace('Some::sub3', sub { 'new data3' });
-
-If replacing the subroutine succeeds, the object is returned.  This allows the
-programmer to chain the calls, if this style of programming is preferred:
-
-    $override->replace('Some::sub1', sub { 'new data1' })
-             ->replace('Some::sub2', sub { 'new data2' })
-             ->replace('Some::sub3', sub { 'new data3' });
+    $override->replace(
+      'Some::sub1' => sub { 'new data1' },
+      'Some::sub2' => sub { 'new data2' },
+      'Some::sub3' => sub { 'new data3' },
+    );
 
 If the subroutine has a prototype, the new subroutine should be declared with
 same prototype as original one:
 
-    $override->replace('Some::sub_with_proto', sub ($$) { ($_[0], $_ [1]) });
+    $override->replace('Some::sub_with_proto' => sub ($$) { ($_[0], $_ [1]) });
 
 A subroutine may be replaced as many times as desired.  This is most useful
 when testing how code behaves with multiple conditions.
 
-    $override->replace('Some::thing', sub { 0 });
+    $override->replace('Some::thing' => sub { 0 });
     is($object->foo, 'wibble', 'wibble is returned if Some::thing is false');
 
-    $override->replace('Some::thing', sub { 1 });
+    $override->replace('Some::thing' => sub { 1 });
     is($object->foo, 'puppies', 'puppies are returned if Some::thing is true');
 
 ## Injecting a subroutine
 
-If you want to inject a subroutine into a package, you can use the `inject()`
-method. This is identical to `replace()`, except that it requires that the
-subroutine does not exist:
+If you want to inject a new subroutine into a package, you can use the
+`inject()` method. This is identical to `replace()`, except that it
+requires that the subroutine does not previously exist:
 
-    $override->inject('Some::sub', sub {'new data'});
+    $override->inject('Some::sub' => sub {'new data'});
 
 This is useful if you want to add a subroutine to a package that doesn't
 already have it.
@@ -103,14 +98,14 @@ already have it.
 If you attempt to inject a subroutine that already exists, an exception will be
 thrown.
 
-    $override->inject('Some::sub', sub {'new data'}); # works
-    $override->inject('Some::sub', sub {'new data'}); # throws an exception
+    $override->inject('Some::sub' => sub {'new data'}); # works
+    $override->inject('Some::sub' => sub {'new data'}); # throws an exception
 
-Calling `restore()` or allowing the `$override` to go out of scope will
-remove the injected subroutine.
+You can restore your injection if you want to re-inject:
 
-    $override->inject('Some::sub', sub {'new data'});
-    $override->restore('Some::sub'); # removes the injected subroutine
+    $override->inject('Some::sub' => sub {'new data'}); # works
+    $override->restore;
+    $override->inject('Some::sub' => sub {'new data'}); # works
 
 ## Inheriting a subroutine
 
@@ -126,6 +121,8 @@ exist in the child:
     use parent 'Parent';
     sub foo {}
 
+    $override->inherit('Child::bar' => sub {'new data'});
+
 'Inherit' will allow you to set up a new 'Child::bar' subroutine since it is
 inherited from Parent. Attempting to 'inherit' 'Child::foo' will result in an
 exception being thrown since 'foo' already exists in Child. Similarly,
@@ -140,11 +137,11 @@ For this you can specify `wrap` instead of `replace`. `wrap` is identical to
 `replace`, except the original subroutine is passed as the first arg to your
 new subroutine. You can call the original sub via 'shift->(@\_)':
 
-    $override->wrap('Some::sub',
+    $override->wrap('Some::sub' =>
       sub {
-        my ($old_sub, @args) = @_;
+        my ($orig, @args) = @_;
         return 1 if $args[0];
-        return $old_sub->(@args);
+        return $orig->(@args);
       }
     );
 
@@ -153,24 +150,40 @@ new subroutine. You can call the original sub via 'shift->(@\_)':
 If the object falls out of scope, the original subs are restored.  However, if
 you need to restore a subroutine early, just use the `restore()` method:
 
-    my $override = Sub::Override->new('Some::sub', sub {'new data'});
+    my $override = Sub::Override->new('Some::sub' => sub {'new data'});
     # do stuff
     $override->restore;
 
 Which is somewhat equivalent to:
 
     {
-      my $override = Sub::Override->new('Some::sub', sub {'new data'});
-      # do stuff
+      my $override = Sub::Override->new('Some::sub' => sub {'new data'});
+      # do stuff, then go out of scope and restore.
     }
 
 If you have overridden more than one subroutine with an override object, you
-will have to explicitly name the subroutine you wish to restore:
+can name individual subroutine(s) you wish to restore:
 
-    $override->restore('This::sub');
+    $override->restore('This::sub', 'That::sub');
+
+If you simply call `restore()` with no arguments, all routines that have been
+overridden will be restored, leaving the environment in the original state.
 
 Note `restore()` will always restore the original behavior of the subroutine
 no matter how many times you have overridden it.
+
+## Chaining calls
+
+All override routines return the override object, allowing you to chain calls:
+
+    $sub->replace(
+      'This::sub' => sub {1},
+      'That::sub' => sub {2},
+    )->inject(
+      'Some::Class::this => sub {3},
+    )->wrap(
+      'Some::Class::that => sub {4},
+    );
 
 ## Which package is the subroutine in?
 
@@ -191,60 +204,54 @@ current package.
 ## new
 
     my $sub = Sub::Override->new;
-    my $sub = Sub::Override->new($sub_name, $sub_ref);
+    my $sub = Sub::Override->new($new_sub_ref => $sub_ref);
 
-Creates a new `Sub::Override` instance.  Optionally, you may override a
+Creates a new `Sub::Override` instance.  Optionally, you may replace a
 subroutine while creating a new object.
 
 ## replace
 
-    $sub->replace($sub_name, $sub_body);
+    $sub->replace($new_sub_ref => $sub_body);
 
-Temporarily replaces a subroutine with another subroutine.  Returns the
-instance, so chaining the method is allowed:
-
-    $sub->replace($sub_name, $sub_body)
-        ->replace($another_sub, $another_body);
+Temporarily replaces a subroutine with another subroutine.
 
 This method will `croak` if the subroutine to be replaced does not exist.
 
 ## override
 
     my $sub = Sub::Override->new;
-    $sub->override($sub_name, $sub_body);
+    $sub->override($new_sub_ref => $sub_body);
 
 `override` is an alternate name for `replace`.  They are the same method.
 
 ## inject
 
-    $sub->inject($sub_name, $sub_body);
+    $sub->inject($new_sub_ref => $sub_body);
 
 Temporarily injects a subroutine into a package.  Returns the instance, so
 chaining the method is allowed:
 
-    $sub->inject($sub_name, $sub_body)
-        ->inject($another_sub, $another_body);
-
 ## inherit
 
-    $sub->inherit($sub_name, $sub_body);
+    $sub->inherit($new_sub_ref => $sub_body);
 
 Checks that the subroutine exists in a parent class, but not in the current
 class, and injects it into the current class to inherit the parent's version.
 
-## restore
-
-    $sub->restore($sub_name);
-
-Restores the previous behavior of the subroutine.  This will happen
-automatically if the `Sub::Override` object falls out of scope.
-
 ## wrap
 
-    $sub->wrap($sub_name, $sub_body);
+    $sub->wrap($new_sub_ref => $sub_body);
 
 Temporarily wraps a subroutine with another subroutine. The original subroutine
 is passed as the first arg to the new subroutine.
+
+## restore
+
+    $sub->restore($sub1, $sub2);
+
+Restores the previous behavior of the specified subroutine(s).  Passing no
+args will restore all overridden subs.  This will also happen automatically if
+the `Sub::Override` object falls out of scope.
 
 # EXPORT
 

--- a/lib/Sub/Override.pm
+++ b/lib/Sub/Override.pm
@@ -386,14 +386,14 @@ current package.
 =head2 new
 
   my $sub = Sub::Override->new;
-  my $sub = Sub::Override->new($new_sub_ref => $sub_ref);
+  my $sub = Sub::Override->new($sub_name => $sub_ref);
 
 Creates a new C<Sub::Override> instance.  Optionally, you may replace a
 subroutine while creating a new object.
 
 =head2 replace
 
-  $sub->replace($new_sub_ref => $sub_body);
+  $sub->replace($sub_name => $sub_body);
 
 Temporarily replaces a subroutine with another subroutine.
 
@@ -402,27 +402,27 @@ This method will C<croak> if the subroutine to be replaced does not exist.
 =head2 override
 
   my $sub = Sub::Override->new;
-  $sub->override($new_sub_ref => $sub_body);
+  $sub->override($sub_name => $sub_body);
 
 C<override> is an alternate name for C<replace>.  They are the same method.
 
 =head2 inject
 
-  $sub->inject($new_sub_ref => $sub_body);
+  $sub->inject($sub_name => $sub_body);
 
 Temporarily injects a subroutine into a package.  Returns the instance, so
 chaining the method is allowed:
 
 =head2 inherit
 
-  $sub->inherit($new_sub_ref => $sub_body);
+  $sub->inherit($sub_name => $sub_body);
 
 Checks that the subroutine exists in a parent class, but not in the current
 class, and injects it into the current class to inherit the parent's version.
 
 =head2 wrap
 
-  $sub->wrap($new_sub_ref => $sub_body);
+  $sub->wrap($sub_name => $sub_body);
 
 Temporarily wraps a subroutine with another subroutine. The original subroutine
 is passed as the first arg to the new subroutine.

--- a/t/override.t
+++ b/t/override.t
@@ -138,7 +138,6 @@ can_ok( $override, 'inject' );
 
     package TempInject;
     sub foo      { 23 }
-    sub bar ($$) { $_[0] + $_[1] }
 
     my $override = $CLASS->new;
 


### PR DESCRIPTION
I was working on the new Sub::Override::Moose and realized it would be relatively simple to change the args to the overrides from one-at-a-time to a hash. I think this will be the last of the changes.